### PR TITLE
BAM-915 chore: add default .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# Singtime - Default EditorConfig
+#
+# References:
+#   https://EditorConfig.org
+#   https://editorconfig-specification.readthedocs.io/
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
# Description

This PR adds a simple default `.editorconfig` file, which is supported by most editors and IDEs we use at BAM (emacs/vi with some additional modules, vscode, Jetbrains IDEs, xcode.

# Notes

While this PR only adds this `.editorconfig` to this `website-tests` repository, we'll likely want to have it added to a lot of other projects as well (or variations of it).

