### PR TITLE
BAM-986 Add trace on failure and remove unnecessary comments

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,8 +27,8 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. */
     actionTimeout: 6000,
 
-    /* Collect trace when a test fail. Check at the end of the report*/
-    trace: 'retain-on-failure',
+    /* Collect trace of each test. Check at the end of the report*/
+    trace: 'on',
   },
 
   /* Configure projects for major browsers */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,12 +3,6 @@ import { devices } from '@playwright/test';
 
 /**
  * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
-
-/**
- * See https://playwright.dev/docs/test-configuration.
  */
 const config: PlaywrightTestConfig = {
   testDir: './tests',
@@ -17,7 +11,6 @@ const config: PlaywrightTestConfig = {
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
-     * For example in `await expect(locator).toHaveText();`
      */
     timeout: 5000,
   },
@@ -27,17 +20,15 @@ const config: PlaywrightTestConfig = {
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  /* Reporter to use. */
   reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  /* Shared settings for all the projects below. */
   use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    /* Maximum time each action such as `click()` can take. */
     actionTimeout: 6000,
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /* Collect trace when retrying the failed test. Check at the end of the report*/
+    trace: 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */
@@ -62,44 +53,7 @@ const config: PlaywrightTestConfig = {
         ...devices['Desktop Safari'],
       },
     },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: {
-    //     ...devices['Pixel 5'],
-    //   },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: {
-    //     ...devices['iPhone 12'],
-    //   },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: {
-    //     channel: 'msedge',
-    //   },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: {
-    //     channel: 'chrome',
-    //   },
-    // },
   ],
-
-  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
-  // outputDir: 'test-results/',
-
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   port: 3000,
-  // },
 };
 
 export default config;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. */
     actionTimeout: 6000,
 
-    /* Collect trace when retrying the failed test. Check at the end of the report*/
+    /* Collect trace when a test fail. Check at the end of the report*/
     trace: 'retain-on-failure',
   },
 


### PR DESCRIPTION
** Bam 986 test as a backend user i get a notification as soon as a price is wrong **

- Add trace for each test which fails below the list of error
- Remove unnecessary comments